### PR TITLE
fix(component/event-carousel): use object cover for image

### DIFF
--- a/src/components/event-carousel.tsx
+++ b/src/components/event-carousel.tsx
@@ -10,13 +10,14 @@ export const EventCard = ({ src, alt }: { src: string; alt: string }) => {
         <CarouselItem className="pl-2 sm:pl-3 md:pl-4 basis-4/5 sm:basis-1/2 lg:basis-1/3">
             <div className="w-full aspect-[4/3] relative rounded-lg overflow-hidden group">
                 <Image
-                    className="object-contain w-full h-full filter grayscale brightness-75 transition-all duration-300"
+                    className="object-cover w-full h-full filter grayscale brightness-75 transition-all duration-300"
                     src={src}
                     alt={alt}
                     fill
-                />
+                >
+                </Image>
                 {/* Purple gradient overlay from bottom */}
-                <div className="h-2/5 absolute inset-0 top-auto bottom-5 bg-gradient-to-t from-purple-600/70 via-purple-500/30 to-transparent opacity-80 pointer-events-none" />
+                <div className="h-2/5 absolute inset-0 top-auto bg-gradient-to-t from-purple-600/70 via-purple-500/30 to-transparent opacity-80 pointer-events-none" />
             </div>
         </CarouselItem>
     );


### PR DESCRIPTION
Use object cover for image instead of object contain since the image have aspect class and cropped part is small